### PR TITLE
跳跃时间二次修正

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,6 +1,8 @@
 {
     "under_game_score_y": 300, 
-    "press_coefficient": 1.392, 
+    "press_coefficient": 1.7, 
+    "press_base_time": 600, 
+    "press_coefficient_fix": 4000
     "piece_base_height_1_2": 20, 
-    "piece_body_width": 70
+    "piece_body_width": 70, 
 }

--- a/wechat_jump_auto.py
+++ b/wechat_jump_auto.py
@@ -32,6 +32,8 @@ with open('config.json','r') as f:
 # Magic Number，不设置可能无法正常执行，请根据具体截图从上到下按需设置
 under_game_score_y = config['under_game_score_y']     # 截图中刚好低于分数显示区域的 Y 坐标，300 是 1920x1080 的值，2K 屏、全面屏请根据实际情况修改
 press_coefficient = config['press_coefficient']       # 长按的时间系数，请自己根据实际情况调节
+press_base_time = config['press_base_time']           # 长按时间的二次修正基点，请自己根据实际情况调节
+press_coefficient_fix = config['press_coefficient_fix']   # 长按时间的二次修正系数，请自己根据实际情况调节
 piece_base_height_1_2 = config['piece_base_height_1_2']   # 二分之一的棋子底座高度，可能要调节
 piece_body_width = config['piece_body_width']             # 棋子的宽度，比截图中量到的稍微大一点比较安全，可能要调节
 
@@ -83,9 +85,11 @@ def set_button_position(im):
 
 def jump(distance):
     press_time = distance * press_coefficient
+    #press_time = distance * 1.1 + distance * distance * 0.00095
+    press_time = press_time * (1 + (600 - press_time) / 4000)    # 长按时间的二次修正
     press_time = max(press_time, 200)   # 设置 200 ms 是最小的按压时间
     press_time = int(press_time)
-    cmd = 'adb shell input swipe {} {} {} {} {}'.format(swipe_x1, swipe_y1, swipe_x2, swipe_y2, press_time)
+    cmd = 'adb shell input swipe {} {} {} {} {} '.format(swipe_x1, swipe_y1, swipe_x2, swipe_y2, press_time)
     print(cmd)
     os.system(cmd)
 


### PR DESCRIPTION
经过实验发现，长按时间和跳跃距离并不是线性相关。
经过拟合，发现长按时间可以由一个二次多项式近似得出。
在保有原来结构不变的基础上，我加入了“二次修正基点”和"二次修正系数"两个参数，对长按时间多进行了一个二次修正。

经过500余次跳跃实验，在1080x1920的屏幕上使用基点=600&系数=4000为例
原来跳在正中心点的几率为10%不到，而且基本是有前有后，并不准确。
进行二次修正后，跳在正中点的概率至少上升到70%以上，并且出现过连续15+次正中中心点的成绩。

可以认为，二次修正可以有效提高命中率，从而提高成绩，并且借由正中的额外分数，更快到达高分。